### PR TITLE
Add filter command

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,6 +20,10 @@ checkstyle {
     toolVersion = '10.2'
 }
 
+run {
+    enableAssertions = true
+}
+
 test {
     useJUnitPlatform()
     finalizedBy jacocoTestReport

--- a/src/main/java/seedu/address/logic/commands/FilterCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FilterCommand.java
@@ -5,7 +5,7 @@ import static java.util.Objects.requireNonNull;
 import seedu.address.commons.util.ToStringBuilder;
 import seedu.address.logic.Messages;
 import seedu.address.model.Model;
-import seedu.address.model.person.NameContainsKeywordsPredicate;
+import seedu.address.model.person.StudentHasSameIdPredicate;
 
 /**
  * Filters the students based on their class id.
@@ -19,9 +19,9 @@ public class FilterCommand extends Command {
             + "Parameters: classId\n"
             + "Example: " + COMMAND_WORD + " CS1101S03";
 
-    private final NameContainsKeywordsPredicate predicate;
+    private final StudentHasSameIdPredicate predicate;
 
-    public FilterCommand(NameContainsKeywordsPredicate predicate) {
+    public FilterCommand(StudentHasSameIdPredicate predicate) {
         this.predicate = predicate;
     }
 

--- a/src/main/java/seedu/address/logic/commands/FilterCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FilterCommand.java
@@ -1,0 +1,57 @@
+package seedu.address.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+
+import seedu.address.commons.util.ToStringBuilder;
+import seedu.address.logic.Messages;
+import seedu.address.model.Model;
+import seedu.address.model.person.NameContainsKeywordsPredicate;
+
+/**
+ * Filters the students based on their class id.
+ */
+public class FilterCommand extends Command {
+
+    public static final String COMMAND_WORD = "filter";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Filters the students based on the given "
+            + "class id (case-insensitive) and displays them as a list.\n"
+            + "Parameters: classId\n"
+            + "Example: " + COMMAND_WORD + " CS1101S03";
+
+    private final NameContainsKeywordsPredicate predicate;
+
+    public FilterCommand(NameContainsKeywordsPredicate predicate) {
+        this.predicate = predicate;
+    }
+
+    @Override
+    public CommandResult execute(Model model) {
+        requireNonNull(model);
+        model.updateFilteredPersonList(predicate);
+        return new CommandResult(
+                String.format(Messages.MESSAGE_PERSONS_LISTED_OVERVIEW, model.getFilteredPersonList().size()));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof FilterCommand)) {
+            return false;
+        }
+
+        FilterCommand otherFilterCommand = (FilterCommand) other;
+        return predicate.equals(otherFilterCommand.predicate);
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this)
+                .add("predicate", predicate)
+                .toString();
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -14,6 +14,7 @@ import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.DeleteCommand;
 import seedu.address.logic.commands.EditCommand;
 import seedu.address.logic.commands.ExitCommand;
+import seedu.address.logic.commands.FilterCommand;
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListCommand;
@@ -64,6 +65,9 @@ public class AddressBookParser {
 
         case ClearCommand.COMMAND_WORD:
             return new ClearCommand();
+
+        case FilterCommand.COMMAND_WORD:
+            return new FilterCommandParser().parse(arguments);
 
         case FindCommand.COMMAND_WORD:
             return new FindCommandParser().parse(arguments);

--- a/src/main/java/seedu/address/logic/parser/FilterCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FilterCommandParser.java
@@ -1,0 +1,29 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
+import seedu.address.logic.commands.FilterCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.person.StudentHasSameIdPredicate;
+
+/**
+ * Parses input arguments and creates a new FilterCommand object
+ */
+public class FilterCommandParser implements Parser<FilterCommand> {
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the FilterCommand
+     * and returns a FilterCommand object for execution.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public FilterCommand parse(String args) throws ParseException {
+        try {
+            String classId = ParserUtil.parseClassId(args).value;
+            return new FilterCommand(new StudentHasSameIdPredicate(classId));
+        } catch (ParseException pe) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, FilterCommand.MESSAGE_USAGE));
+        }
+    }
+
+}

--- a/src/main/java/seedu/address/model/person/StudentHasSameIdPredicate.java
+++ b/src/main/java/seedu/address/model/person/StudentHasSameIdPredicate.java
@@ -1,0 +1,43 @@
+package seedu.address.model.person;
+
+import java.util.function.Predicate;
+
+import seedu.address.commons.util.ToStringBuilder;
+
+/**
+ * Tests that a {@code Person}'s {@code ClassId} matches the given class id.
+ */
+public class StudentHasSameIdPredicate implements Predicate<Person> {
+    private final String classId;
+
+    public StudentHasSameIdPredicate(String classId) {
+        this.classId = classId;
+    }
+
+    @Override
+    public boolean test(Person person) {
+        String idToTest = person.getAddress().value.toLowerCase();
+        String classIdCopy = classId.toLowerCase();
+        return classIdCopy.equals(idToTest);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof StudentHasSameIdPredicate)) {
+            return false;
+        }
+
+        StudentHasSameIdPredicate otherStudentHasSameIdPredicate = (StudentHasSameIdPredicate) other;
+        return classId.equals(otherStudentHasSameIdPredicate.classId);
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this).add("classId", classId).toString();
+    }
+}

--- a/src/main/java/seedu/address/model/person/StudentHasSameIdPredicate.java
+++ b/src/main/java/seedu/address/model/person/StudentHasSameIdPredicate.java
@@ -11,7 +11,7 @@ public class StudentHasSameIdPredicate implements Predicate<Person> {
     private final String classId;
 
     public StudentHasSameIdPredicate(String classId) {
-        this.classId = classId;
+        this.classId = classId.toLowerCase();
     }
 
     @Override

--- a/src/test/java/seedu/address/logic/commands/FilterCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/FilterCommandTest.java
@@ -1,0 +1,91 @@
+package seedu.address.logic.commands;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.logic.Messages.MESSAGE_PERSONS_LISTED_OVERVIEW;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
+
+import java.util.Collections;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+import seedu.address.model.person.Person;
+import seedu.address.model.person.StudentHasSameIdPredicate;
+import seedu.address.testutil.PersonBuilder;
+
+/**
+ * Contains integration tests (interaction with the Model) for {@code FindCommand}.
+ */
+public class FilterCommandTest {
+    private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+    private Model expectedModel = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+
+    @Test
+    public void equals() {
+        StudentHasSameIdPredicate firstPredicate = new StudentHasSameIdPredicate("CS1101S03");
+        StudentHasSameIdPredicate secondPredicate = new StudentHasSameIdPredicate("CS2040S");
+
+        FilterCommand filterFirstCommand = new FilterCommand(firstPredicate);
+        FilterCommand filterSecondCommand = new FilterCommand(secondPredicate);
+
+        // same object -> returns true
+        assertTrue(filterFirstCommand.equals(filterFirstCommand));
+
+        // same values -> returns true
+        FilterCommand filterFirstCommandCopy = new FilterCommand(firstPredicate);
+        assertTrue(filterFirstCommand.equals(filterFirstCommandCopy));
+
+        // different types -> returns false
+        assertFalse(filterFirstCommand.equals(1));
+
+        // null -> returns false
+        assertFalse(filterFirstCommand.equals(null));
+
+        // different class id's-> returns false
+        assertFalse(filterFirstCommand.equals(filterSecondCommand));
+    }
+
+    @Test
+    public void execute_emptyId_noIdFound() {
+        String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 0);
+        // A class id that doesn't exist
+        StudentHasSameIdPredicate predicate = new StudentHasSameIdPredicate("");
+        FilterCommand command = new FilterCommand(predicate);
+        expectedModel.updateFilteredPersonList(predicate);
+        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+        assertEquals(Collections.emptyList(), model.getFilteredPersonList());
+    }
+
+    @Test
+    public void execute_oneId_twoPersonsFound() {
+        String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 2);
+        StudentHasSameIdPredicate predicate = new StudentHasSameIdPredicate("CS210501");
+        Person james = new PersonBuilder().withName("James").withStudentId("A7777777F")
+                .withEmailId("E1230495").withAddress("CS210501").build();
+        Person raj = new PersonBuilder().withName("Rajaratnam").withStudentId("A4444444G")
+                .withEmailId("E5938475").withAddress("CS210501").build();
+        expectedModel.updateFilteredPersonList(predicate);
+        model.addPerson(james);
+        model.addPerson(raj);
+        expectedModel.addPerson(james);
+        expectedModel.addPerson(raj);
+        FilterCommand command = new FilterCommand(predicate);
+        model.updateFilteredPersonList(predicate);
+        expectedModel.updateFilteredPersonList(predicate);
+        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+        assertEquals(expectedModel.getFilteredPersonList(), model.getFilteredPersonList());
+    }
+
+    @Test
+    public void toStringMethod() {
+        StudentHasSameIdPredicate predicate = new StudentHasSameIdPredicate(("CS210605"));
+        FilterCommand filterCommand = new FilterCommand(predicate);
+        String expected = FilterCommand.class.getCanonicalName() + "{predicate=" + predicate + "}";
+        assertEquals(expected, filterCommand.toString());
+    }
+}

--- a/src/test/java/seedu/address/logic/parser/FilterCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FilterCommandParserTest.java
@@ -1,0 +1,36 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.commands.FilterCommand;
+import seedu.address.model.person.StudentHasSameIdPredicate;
+
+public class FilterCommandParserTest {
+
+    private FilterCommandParser parser = new FilterCommandParser();
+
+    @Test
+    public void parse_emptyArg_throwsParseException() {
+        assertParseFailure(parser, "     ", String.format(MESSAGE_INVALID_COMMAND_FORMAT, FilterCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_validArgs_returnsFilterCommand() {
+        String validClassId = "CS323019";
+        FilterCommand expectedFilterCommand =
+                new FilterCommand(new StudentHasSameIdPredicate(validClassId));
+        // class id's match
+        assertParseSuccess(parser, "CS323019", expectedFilterCommand);
+
+        // class id with leading and trailing whitespaces
+        assertParseSuccess(parser, "  CS323019  ", expectedFilterCommand);
+
+        // case insensitive
+        assertParseSuccess(parser, "cs323019", expectedFilterCommand);
+    }
+
+}

--- a/src/test/java/seedu/address/model/person/StudentHasSameIdPredicateTest.java
+++ b/src/test/java/seedu/address/model/person/StudentHasSameIdPredicateTest.java
@@ -1,0 +1,59 @@
+package seedu.address.model.person;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.testutil.PersonBuilder;
+
+public class StudentHasSameIdPredicateTest {
+
+    @Test
+    public void equals() {
+        // Same class id -> returns true
+        StudentHasSameIdPredicate firstPredicate = new StudentHasSameIdPredicate("CS323019");
+        StudentHasSameIdPredicate secondPredicate = new StudentHasSameIdPredicate("CS323019");
+        assertTrue(firstPredicate.equals(secondPredicate));
+
+        // different class ids -> returns false
+        StudentHasSameIdPredicate thirdPredicate = new StudentHasSameIdPredicate("CS1101S");
+        assertFalse(firstPredicate.equals(thirdPredicate));
+
+        // different types -> returns false
+        assertFalse(firstPredicate.equals(1));
+
+        // Null -> returns false
+        assertFalse(firstPredicate.equals(null));
+    }
+
+    @Test
+    public void test_classIdMatches_returnsTrue() {
+        // matching class ids
+        StudentHasSameIdPredicate predicate = new StudentHasSameIdPredicate("CS323019");
+        assertTrue(predicate.test(new PersonBuilder().withAddress("CS323019").build()));
+
+        // matching class ids but with different case
+        predicate = new StudentHasSameIdPredicate("cs323019");
+        assertTrue(predicate.test(new PersonBuilder().withAddress("CS323019").build()));
+    }
+
+    @Test
+    public void test_classIdDoesNotMatch_returnsFalse() {
+        // non-matching class ids
+        StudentHasSameIdPredicate predicate = new StudentHasSameIdPredicate("CS323019");
+        assertFalse(predicate.test(new PersonBuilder().withAddress("CS1101S").build()));
+
+        // non-matching with different case
+        predicate = new StudentHasSameIdPredicate("CS323019");
+        assertFalse(predicate.test(new PersonBuilder().withAddress("cs1101s").build()));
+    }
+
+    @Test
+    public void toStringMethod() {
+        StudentHasSameIdPredicate predicate = new StudentHasSameIdPredicate("CS323019");
+        String expected = StudentHasSameIdPredicate.class.getCanonicalName() + "{classId=cs323019}";
+        assertEquals(expected, predicate.toString());
+    }
+}


### PR DESCRIPTION
* User can now filter students by classId by typing **filter classId**
* For example: filter CS210611
* Add FilterCommand, FilterCommandParser and StudentHasSameIdPredicate classes but they do not cause any checks/tests to fail

Fixes #58 