### PR TITLE
Create new mass_delete command

### DIFF
--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -96,7 +96,7 @@ public class EditCommand extends Command {
         assert personToEdit != null;
 
         Name updatedName = editPersonDescriptor.getName().orElse(personToEdit.getName());
-        StudentId updatedStudentId = editPersonDescriptor.getPhone().orElse(personToEdit.getStudentId());
+        StudentId updatedStudentId = editPersonDescriptor.getStudentId().orElse(personToEdit.getStudentId());
         EmailId updatedEmailId = editPersonDescriptor.getEmail().orElse(personToEdit.getEmail());
         ClassId updatedClassId = editPersonDescriptor.getAddress().orElse(personToEdit.getAddress());
         Set<Tag> updatedTags = editPersonDescriptor.getTags().orElse(personToEdit.getTags());
@@ -147,7 +147,7 @@ public class EditCommand extends Command {
          */
         public EditPersonDescriptor(EditPersonDescriptor toCopy) {
             setName(toCopy.name);
-            setPhone(toCopy.studentId);
+            setStudentId(toCopy.studentId);
             setEmail(toCopy.emailId);
             setAddress(toCopy.classId);
             setTags(toCopy.tags);
@@ -168,11 +168,11 @@ public class EditCommand extends Command {
             return Optional.ofNullable(name);
         }
 
-        public void setPhone(StudentId studentId) {
+        public void setStudentId(StudentId studentId) {
             this.studentId = studentId;
         }
 
-        public Optional<StudentId> getPhone() {
+        public Optional<StudentId> getStudentId() {
             return Optional.ofNullable(studentId);
         }
 

--- a/src/main/java/seedu/address/logic/commands/MultipleDeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/MultipleDeleteCommand.java
@@ -1,0 +1,42 @@
+package seedu.address.logic.commands;
+
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.person.StudentId;
+
+/**
+ * Deletes multiple students using their student ids at the same time.
+ */
+public class MultipleDeleteCommand extends Command {
+
+    // need to add tests as well
+
+    public static final String COMMAND_WORD = "m_delete";
+
+    // need to change message
+    public static final String MESSAGE_SUCCESS = "All persons deleted successfully.";
+
+    private StudentId[] studentIdsToRemove;
+
+    public MultipleDeleteCommand(StudentId[] studentIdArray) {
+        this.studentIdsToRemove = studentIdArray;
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        // need to polish this
+        int numStudentIdsToRemove = studentIdsToRemove.length;
+        DeleteCommand[] deleteCommandsToExecute = new DeleteCommand[numStudentIdsToRemove];
+        for (int i = 0; i < numStudentIdsToRemove; i++) {
+            StudentId studentIdToRemove = studentIdsToRemove[i];
+            deleteCommandsToExecute[i] = new DeleteCommand(studentIdToRemove);
+        }
+
+        for (DeleteCommand deleteCommandToExecute : deleteCommandsToExecute) {
+            deleteCommandToExecute.execute(model);
+        }
+
+        return new CommandResult(MESSAGE_SUCCESS);
+    }
+
+}

--- a/src/main/java/seedu/address/logic/parser/AddCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddCommandParser.java
@@ -41,7 +41,7 @@ public class AddCommandParser implements Parser<AddCommand> {
 
         argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_NAME, PREFIX_STUDENT_ID, PREFIX_EMAIL_ID, PREFIX_CLASS_ID);
         Name name = ParserUtil.parseName(argMultimap.getValue(PREFIX_NAME).get());
-        StudentId studentId = ParserUtil.parsePhone(argMultimap.getValue(PREFIX_STUDENT_ID).get());
+        StudentId studentId = ParserUtil.parseStudentId(argMultimap.getValue(PREFIX_STUDENT_ID).get());
         EmailId emailId = ParserUtil.parseEmail(argMultimap.getValue(PREFIX_EMAIL_ID).get());
         ClassId classId = ParserUtil.parseClassId(argMultimap.getValue(PREFIX_CLASS_ID).get());
         Set<Tag> tagList = ParserUtil.parseTags(argMultimap.getAllValues(PREFIX_TAG));

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -17,6 +17,7 @@ import seedu.address.logic.commands.ExitCommand;
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListCommand;
+import seedu.address.logic.commands.MultipleDeleteCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 
 /**
@@ -76,6 +77,9 @@ public class AddressBookParser {
 
         case HelpCommand.COMMAND_WORD:
             return new HelpCommand();
+
+        case MultipleDeleteCommand.COMMAND_WORD:
+            return new MultipleDeleteCommandParser().parse(arguments);
 
         default:
             logger.finer("This user input caused a ParseException: " + userInput);

--- a/src/main/java/seedu/address/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditCommandParser.java
@@ -51,7 +51,7 @@ public class EditCommandParser implements Parser<EditCommand> {
             editPersonDescriptor.setName(ParserUtil.parseName(argMultimap.getValue(PREFIX_NAME).get()));
         }
         if (argMultimap.getValue(PREFIX_STUDENT_ID).isPresent()) {
-            editPersonDescriptor.setPhone(ParserUtil.parsePhone(argMultimap.getValue(PREFIX_STUDENT_ID).get()));
+            editPersonDescriptor.setStudentId(ParserUtil.parseStudentId(argMultimap.getValue(PREFIX_STUDENT_ID).get()));
         }
         if (argMultimap.getValue(PREFIX_EMAIL_ID).isPresent()) {
             editPersonDescriptor.setEmail(ParserUtil.parseEmail(argMultimap.getValue(PREFIX_EMAIL_ID).get()));

--- a/src/main/java/seedu/address/logic/parser/MultipleDeleteCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/MultipleDeleteCommandParser.java
@@ -1,0 +1,22 @@
+package seedu.address.logic.parser;
+
+import seedu.address.logic.commands.MultipleDeleteCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.person.StudentId;
+
+/**
+ * Parses arguments and creates MultipleDeleteCommand object.
+ */
+public class MultipleDeleteCommandParser implements Parser<MultipleDeleteCommand> {
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the MultipleDeleteCommand
+     * and returns a MultipleDeleteCommand object for execution.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public MultipleDeleteCommand parse(String userInput) throws ParseException {
+        StudentId[] studentIdsToRemove = ParserUtil.parseMultipleStudentIds(userInput);
+        return new MultipleDeleteCommand(studentIdsToRemove);
+    }
+
+}

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -53,21 +53,6 @@ public class ParserUtil {
     }
 
     /**
-     * Parses a {@code String phone} into a {@code StudentId}.
-     * Leading and trailing whitespaces will be trimmed.
-     *
-     * @throws ParseException if the given {@code phone} is invalid.
-     */
-    public static StudentId parsePhone(String phone) throws ParseException {
-        requireNonNull(phone);
-        String trimmedPhone = phone.trim();
-        if (!StudentId.isValidStudentId(trimmedPhone)) {
-            throw new ParseException(StudentId.MESSAGE_CONSTRAINTS);
-        }
-        return new StudentId(trimmedPhone);
-    }
-
-    /**
      * Parses a {@code String classId} into a {@code ClassId}.
      * Leading and trailing whitespaces will be trimmed.
      *

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -86,7 +86,7 @@ public class ParserUtil {
      * Parses a {@code String studentIdString} into an {@code StudentId}.
      * Leading and trailing whitespaces will be trimmed.
      *
-     * @throws ParseException if the given {@code studentIdString} is invalid.
+     * @throws ParseException if the given {@code studentIdsString} is invalid.
      */
     public static StudentId parseStudentId(String studentIdString) throws ParseException {
         requireNonNull(studentIdString);
@@ -95,6 +95,31 @@ public class ParserUtil {
             throw new ParseException(StudentId.MESSAGE_CONSTRAINTS);
         }
         return new StudentId(trimmedStudentId);
+    }
+
+    /**
+     * Parses a {@code String studentIdsString} into a {@code StudentId[]}.
+     * Leading and trailing whitespaces will be trimmed.
+     *
+     * @throws ParseException if any of the given {@code studentIdsString} is invalid.
+     */
+    public static StudentId[] parseMultipleStudentIds(String studentIdsString) throws ParseException {
+        requireNonNull(studentIdsString);
+        String[] studentIdStringsArray = separateStringByComma(studentIdsString);
+        int numStudentId = studentIdStringsArray.length;
+        StudentId[] studentIdsArray = new StudentId[numStudentId];
+        for (int i = 0; i < numStudentId; i++) {
+            studentIdsArray[i] = parseStudentId(studentIdStringsArray[i]);
+        }
+        return studentIdsArray;
+    }
+
+    /**
+     * Takes a comma-separated string and breaks it up into a {@code String[]}.
+     */
+    public static String[] separateStringByComma(String s) {
+        String[] stringParts = s.split(",");
+        return stringParts;
     }
 
     /**

--- a/src/test/java/seedu/address/logic/commands/EditPersonDescriptorTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditPersonDescriptorTest.java
@@ -62,7 +62,7 @@ public class EditPersonDescriptorTest {
         EditPersonDescriptor editPersonDescriptor = new EditPersonDescriptor();
         String expected = EditPersonDescriptor.class.getCanonicalName() + "{name="
                 + editPersonDescriptor.getName().orElse(null) + ", studentId="
-                + editPersonDescriptor.getPhone().orElse(null) + ", email="
+                + editPersonDescriptor.getStudentId().orElse(null) + ", email="
                 + editPersonDescriptor.getEmail().orElse(null) + ", address="
                 + editPersonDescriptor.getAddress().orElse(null) + ", tags="
                 + editPersonDescriptor.getTags().orElse(null) + "}";

--- a/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
@@ -81,25 +81,25 @@ public class ParserUtilTest {
 
     @Test
     public void parseStudentId_null_throwsNullPointerException() {
-        assertThrows(NullPointerException.class, () -> ParserUtil.parsePhone((String) null));
+        assertThrows(NullPointerException.class, () -> ParserUtil.parseStudentId((String) null));
     }
 
     @Test
     public void parseStudentId_invalidValue_throwsParseException() {
-        assertThrows(ParseException.class, () -> ParserUtil.parsePhone(INVALID_STUDENT_ID));
+        assertThrows(ParseException.class, () -> ParserUtil.parseStudentId(INVALID_STUDENT_ID));
     }
 
     @Test
     public void parseStudentId_validValueWithoutWhitespace_returnsStudentId() throws Exception {
         StudentId expectedStudentId = new StudentId(VALID_STUDENT_ID);
-        assertEquals(expectedStudentId, ParserUtil.parsePhone(VALID_STUDENT_ID));
+        assertEquals(expectedStudentId, ParserUtil.parseStudentId(VALID_STUDENT_ID));
     }
 
     @Test
     public void parsePhone_validValueWithWhitespace_returnsTrimmedPhone() throws Exception {
-        String phoneWithWhitespace = WHITESPACE + VALID_STUDENT_ID + WHITESPACE;
+        String studentIdWithWhitespace = WHITESPACE + VALID_STUDENT_ID + WHITESPACE;
         StudentId expectedStudentId = new StudentId(VALID_STUDENT_ID);
-        assertEquals(expectedStudentId, ParserUtil.parsePhone(phoneWithWhitespace));
+        assertEquals(expectedStudentId, ParserUtil.parseStudentId(studentIdWithWhitespace));
     }
 
     @Test

--- a/src/test/java/seedu/address/testutil/EditPersonDescriptorBuilder.java
+++ b/src/test/java/seedu/address/testutil/EditPersonDescriptorBuilder.java
@@ -33,7 +33,7 @@ public class EditPersonDescriptorBuilder {
     public EditPersonDescriptorBuilder(Person person) {
         descriptor = new EditPersonDescriptor();
         descriptor.setName(person.getName());
-        descriptor.setPhone(person.getStudentId());
+        descriptor.setStudentId(person.getStudentId());
         descriptor.setEmail(person.getEmail());
         descriptor.setAddress(person.getAddress());
         descriptor.setTags(person.getTags());
@@ -51,7 +51,7 @@ public class EditPersonDescriptorBuilder {
      * Sets the {@code StudentId} of the {@code EditPersonDescriptor} that we are building.
      */
     public EditPersonDescriptorBuilder withPhone(String phone) {
-        descriptor.setPhone(new StudentId(phone));
+        descriptor.setStudentId(new StudentId(phone));
         return this;
     }
 

--- a/src/test/java/seedu/address/testutil/PersonUtil.java
+++ b/src/test/java/seedu/address/testutil/PersonUtil.java
@@ -46,7 +46,7 @@ public class PersonUtil {
     public static String getEditPersonDescriptorDetails(EditPersonDescriptor descriptor) {
         StringBuilder sb = new StringBuilder();
         descriptor.getName().ifPresent(name -> sb.append(PREFIX_NAME).append(name.fullName).append(" "));
-        descriptor.getPhone().ifPresent(phone -> sb.append(PREFIX_STUDENT_ID).append(phone.value).append(" "));
+        descriptor.getStudentId().ifPresent(phone -> sb.append(PREFIX_STUDENT_ID).append(phone.value).append(" "));
         descriptor.getEmail().ifPresent(email -> sb.append(PREFIX_EMAIL_ID).append(email.value).append(" "));
         descriptor.getAddress().ifPresent(address -> sb.append(PREFIX_CLASS_ID).append(address.value).append(" "));
         if (descriptor.getTags().isPresent()) {


### PR DESCRIPTION
Created a new mass delete command that follows the format: ```m_delete [StudentIds]```, where ```[StudentIds]``` is a list of student ids to delete from the contact list. E.g. ```m_delete A1234567H, A2345678B```. 

The implementation is not complete. In the next iteration, I will write some tests and handle the errors related to this command. 