### PR TITLE
Make filter work with tags

### DIFF
--- a/src/main/java/seedu/address/logic/commands/FilterCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FilterCommand.java
@@ -6,30 +6,53 @@ import seedu.address.commons.util.ToStringBuilder;
 import seedu.address.logic.Messages;
 import seedu.address.model.Model;
 import seedu.address.model.person.StudentHasSameClassIdPredicate;
+import seedu.address.model.person.StudentHasSameTagPredicate;
 
 /**
  * Filters the students based on their class id.
  */
 public class FilterCommand extends Command {
 
-    public static final String COMMAND_WORD = "filter";
+    public static final String COMMAND_WORD_CLASS = "filter_c";
+    public static final String COMMAND_WORD_TAG = "filter_t";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Filters and lists the students based on the given "
-            + "class id OR tag (case-insensitive)\n"
+    public static final String MESSAGE_USAGE = COMMAND_WORD_CLASS + ": Filters and lists the students based on"
+            + "the given class id OR tag (case-insensitive)\n"
             + "Parameters: classId OR tag\n"
-            + "Example: " + COMMAND_WORD + " CS1101S03\n"
-            + "Example: " + COMMAND_WORD + " NeedHelp\n";
+            + "Example: " + COMMAND_WORD_CLASS + " CS1101S03\n"
+            + "Example: " + COMMAND_WORD_CLASS + " NeedHelp\n";
 
-    private final StudentHasSameClassIdPredicate predicate;
+    private StudentHasSameClassIdPredicate idPredicate = null;
+    private StudentHasSameTagPredicate tagPredicate = null;
 
-    public FilterCommand(StudentHasSameClassIdPredicate predicate) {
-        this.predicate = predicate;
+    /**
+     * Constructs a {@code FilterCommand}.
+     *
+     * @param idPredicate The predicate matching the id keyed in by the user.
+     */
+    public FilterCommand(StudentHasSameClassIdPredicate idPredicate) {
+        requireNonNull(idPredicate);
+        this.idPredicate = idPredicate;
+    }
+
+    /**
+     * Constructs a {@code FilterCommand}.
+     *
+     * @param tagPredicate The predicate matching the tag keyed in by the user.
+     */
+    public FilterCommand(StudentHasSameTagPredicate tagPredicate) {
+        requireNonNull(tagPredicate);
+        this.tagPredicate = tagPredicate;
     }
 
     @Override
     public CommandResult execute(Model model) {
         requireNonNull(model);
-        model.updateFilteredPersonList(predicate);
+        if (tagPredicate == null) {
+            model.updateFilteredPersonList(idPredicate);
+        } else {
+            model.updateFilteredPersonList(tagPredicate);
+        }
         return new CommandResult(
                 String.format(Messages.MESSAGE_PERSONS_LISTED_OVERVIEW, model.getFilteredPersonList().size()));
     }
@@ -46,13 +69,22 @@ public class FilterCommand extends Command {
         }
 
         FilterCommand otherFilterCommand = (FilterCommand) other;
-        return predicate.equals(otherFilterCommand.predicate);
+        if (tagPredicate == null) {
+            return otherFilterCommand.tagPredicate == null && idPredicate.equals(otherFilterCommand.idPredicate);
+        } else {
+            return otherFilterCommand.idPredicate == null && tagPredicate.equals(otherFilterCommand.tagPredicate);
+        }
     }
 
     @Override
     public String toString() {
+        if (tagPredicate == null) {
+            return new ToStringBuilder(this)
+                    .add("predicate", idPredicate)
+                    .toString();
+        }
         return new ToStringBuilder(this)
-                .add("predicate", predicate)
+                .add("predicate", tagPredicate)
                 .toString();
     }
 }

--- a/src/main/java/seedu/address/logic/commands/FilterCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FilterCommand.java
@@ -5,7 +5,7 @@ import static java.util.Objects.requireNonNull;
 import seedu.address.commons.util.ToStringBuilder;
 import seedu.address.logic.Messages;
 import seedu.address.model.Model;
-import seedu.address.model.person.StudentHasSameIdPredicate;
+import seedu.address.model.person.StudentHasSameClassIdPredicate;
 
 /**
  * Filters the students based on their class id.
@@ -14,14 +14,15 @@ public class FilterCommand extends Command {
 
     public static final String COMMAND_WORD = "filter";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Filters the students based on the given "
-            + "class id (case-insensitive) and displays them as a list.\n"
-            + "Parameters: classId\n"
-            + "Example: " + COMMAND_WORD + " CS1101S03";
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Filters and lists the students based on the given "
+            + "class id OR tag (case-insensitive)\n"
+            + "Parameters: classId OR tag\n"
+            + "Example: " + COMMAND_WORD + " CS1101S03\n"
+            + "Example: " + COMMAND_WORD + " NeedHelp\n";
 
-    private final StudentHasSameIdPredicate predicate;
+    private final StudentHasSameClassIdPredicate predicate;
 
-    public FilterCommand(StudentHasSameIdPredicate predicate) {
+    public FilterCommand(StudentHasSameClassIdPredicate predicate) {
         this.predicate = predicate;
     }
 

--- a/src/main/java/seedu/address/logic/parser/FilterCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FilterCommandParser.java
@@ -4,7 +4,7 @@ import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 
 import seedu.address.logic.commands.FilterCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
-import seedu.address.model.person.StudentHasSameIdPredicate;
+import seedu.address.model.person.StudentHasSameClassIdPredicate;
 
 /**
  * Parses input arguments and creates a new FilterCommand object
@@ -19,7 +19,7 @@ public class FilterCommandParser implements Parser<FilterCommand> {
     public FilterCommand parse(String args) throws ParseException {
         try {
             String classId = ParserUtil.parseClassId(args).value;
-            return new FilterCommand(new StudentHasSameIdPredicate(classId));
+            return new FilterCommand(new StudentHasSameClassIdPredicate(classId));
         } catch (ParseException pe) {
             throw new ParseException(
                     String.format(MESSAGE_INVALID_COMMAND_FORMAT, FilterCommand.MESSAGE_USAGE));

--- a/src/main/java/seedu/address/logic/parser/FilterCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FilterCommandParser.java
@@ -4,12 +4,18 @@ import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 
 import seedu.address.logic.commands.FilterCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.person.ClassId;
 import seedu.address.model.person.StudentHasSameClassIdPredicate;
+import seedu.address.model.person.StudentHasSameTagPredicate;
+import seedu.address.model.tag.Tag;
 
 /**
  * Parses input arguments and creates a new FilterCommand object
  */
 public class FilterCommandParser implements Parser<FilterCommand> {
+
+    public static final String SUFFIX_FILTER_BY_CLASS = "byclass";
+    public static final String SUFFIX_FILTER_BY_TAG = "bytag";
 
     /**
      * Parses the given {@code String} of arguments in the context of the FilterCommand
@@ -18,12 +24,20 @@ public class FilterCommandParser implements Parser<FilterCommand> {
      */
     public FilterCommand parse(String args) throws ParseException {
         try {
-            String classId = ParserUtil.parseClassId(args).value;
-            return new FilterCommand(new StudentHasSameClassIdPredicate(classId));
+            if (args.endsWith(SUFFIX_FILTER_BY_CLASS)) {
+                String trimmedArgs = args.substring(0, args.length() - SUFFIX_FILTER_BY_CLASS.length()).trim();
+                ClassId classId = ParserUtil.parseClassId(trimmedArgs);
+                return new FilterCommand(new StudentHasSameClassIdPredicate(classId));
+            } else if (args.endsWith(SUFFIX_FILTER_BY_TAG)) {
+                String trimmedArgs = args.substring(0, args.length() - SUFFIX_FILTER_BY_TAG.length()).trim();
+                Tag tag = ParserUtil.parseTag(trimmedArgs);
+                return new FilterCommand(new StudentHasSameTagPredicate(tag));
+            }
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, FilterCommand.MESSAGE_USAGE));
         } catch (ParseException pe) {
             throw new ParseException(
                     String.format(MESSAGE_INVALID_COMMAND_FORMAT, FilterCommand.MESSAGE_USAGE));
         }
     }
-
 }

--- a/src/main/java/seedu/address/logic/parser/WhoDatParser.java
+++ b/src/main/java/seedu/address/logic/parser/WhoDatParser.java
@@ -67,8 +67,11 @@ public class WhoDatParser {
         case ClearCommand.COMMAND_WORD:
             return new ClearCommand();
 
-        case FilterCommand.COMMAND_WORD:
-            return new FilterCommandParser().parse(arguments);
+        case FilterCommand.COMMAND_WORD_CLASS:
+            return new FilterCommandParser().parse(arguments + FilterCommandParser.SUFFIX_FILTER_BY_CLASS);
+
+        case FilterCommand.COMMAND_WORD_TAG:
+            return new FilterCommandParser().parse(arguments + FilterCommandParser.SUFFIX_FILTER_BY_TAG);
 
         case FindCommand.COMMAND_WORD:
             return new FindCommandParser().parse(arguments);

--- a/src/main/java/seedu/address/model/person/StudentHasSameClassIdPredicate.java
+++ b/src/main/java/seedu/address/model/person/StudentHasSameClassIdPredicate.java
@@ -8,17 +8,17 @@ import seedu.address.commons.util.ToStringBuilder;
  * Tests that a {@code Person}'s {@code ClassId} matches the given class id.
  */
 public class StudentHasSameClassIdPredicate implements Predicate<Person> {
-    private final String classId;
+    private final ClassId classId;
 
-    public StudentHasSameClassIdPredicate(String classId) {
-        this.classId = classId.toLowerCase();
+    public StudentHasSameClassIdPredicate(ClassId classId) {
+        this.classId = classId;
     }
 
     @Override
     public boolean test(Person person) {
-        String idToTest = person.getClassId().value.toLowerCase();
-        String classIdCopy = classId.toLowerCase();
-        return classIdCopy.equals(idToTest);
+        String currentValue = classId.toString().toLowerCase();
+        String valueToTest = person.getClassId().toString().toLowerCase();
+        return currentValue.equals(valueToTest);
     }
 
     @Override

--- a/src/main/java/seedu/address/model/person/StudentHasSameClassIdPredicate.java
+++ b/src/main/java/seedu/address/model/person/StudentHasSameClassIdPredicate.java
@@ -7,10 +7,10 @@ import seedu.address.commons.util.ToStringBuilder;
 /**
  * Tests that a {@code Person}'s {@code ClassId} matches the given class id.
  */
-public class StudentHasSameIdPredicate implements Predicate<Person> {
+public class StudentHasSameClassIdPredicate implements Predicate<Person> {
     private final String classId;
 
-    public StudentHasSameIdPredicate(String classId) {
+    public StudentHasSameClassIdPredicate(String classId) {
         this.classId = classId.toLowerCase();
     }
 
@@ -28,12 +28,12 @@ public class StudentHasSameIdPredicate implements Predicate<Person> {
         }
 
         // instanceof handles nulls
-        if (!(other instanceof StudentHasSameIdPredicate)) {
+        if (!(other instanceof StudentHasSameClassIdPredicate)) {
             return false;
         }
 
-        StudentHasSameIdPredicate otherStudentHasSameIdPredicate = (StudentHasSameIdPredicate) other;
-        return classId.equals(otherStudentHasSameIdPredicate.classId);
+        StudentHasSameClassIdPredicate otherStudentHasSameClassIdPredicate = (StudentHasSameClassIdPredicate) other;
+        return classId.equals(otherStudentHasSameClassIdPredicate.classId);
     }
 
     @Override

--- a/src/main/java/seedu/address/model/person/StudentHasSameTagPredicate.java
+++ b/src/main/java/seedu/address/model/person/StudentHasSameTagPredicate.java
@@ -6,7 +6,7 @@ import seedu.address.commons.util.ToStringBuilder;
 import seedu.address.model.tag.Tag;
 
 /**
- * Tests that a {@code Person}'s {@code ClassId} matches the given class id.
+ * Tests that a {@code Person}'s {@code Tag} matches the given class id.
  */
 public class StudentHasSameTagPredicate implements Predicate<Person> {
     private final Tag tag;

--- a/src/main/java/seedu/address/model/person/StudentHasSameTagPredicate.java
+++ b/src/main/java/seedu/address/model/person/StudentHasSameTagPredicate.java
@@ -3,22 +3,23 @@ package seedu.address.model.person;
 import java.util.function.Predicate;
 
 import seedu.address.commons.util.ToStringBuilder;
+import seedu.address.model.tag.Tag;
 
 /**
  * Tests that a {@code Person}'s {@code ClassId} matches the given class id.
  */
 public class StudentHasSameTagPredicate implements Predicate<Person> {
-    private final String tag;
+    private final Tag tag;
 
-    public StudentHasSameTagPredicate(String tag) {
-        this.tag = tag.toLowerCase();
+    public StudentHasSameTagPredicate(Tag tag) {
+        this.tag = tag;
     }
 
     @Override
     public boolean test(Person person) {
-        String tagToTest = person.getClassId().value.toLowerCase();
-        String tagCopy = tag.toLowerCase();
-        return tagCopy.equals(tagToTest);
+        String searchTag = tag.toString().toLowerCase();
+        return person.getTags().stream()
+                .anyMatch(t -> t.toString().toLowerCase().equals(searchTag));
     }
 
     @Override

--- a/src/main/java/seedu/address/model/person/StudentHasSameTagPredicate.java
+++ b/src/main/java/seedu/address/model/person/StudentHasSameTagPredicate.java
@@ -1,0 +1,43 @@
+package seedu.address.model.person;
+
+import java.util.function.Predicate;
+
+import seedu.address.commons.util.ToStringBuilder;
+
+/**
+ * Tests that a {@code Person}'s {@code ClassId} matches the given class id.
+ */
+public class StudentHasSameTagPredicate implements Predicate<Person> {
+    private final String tag;
+
+    public StudentHasSameTagPredicate(String tag) {
+        this.tag = tag.toLowerCase();
+    }
+
+    @Override
+    public boolean test(Person person) {
+        String tagToTest = person.getClassId().value.toLowerCase();
+        String tagCopy = tag.toLowerCase();
+        return tagCopy.equals(tagToTest);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof StudentHasSameTagPredicate)) {
+            return false;
+        }
+
+        StudentHasSameTagPredicate otherStudentHasSameTagPredicate = (StudentHasSameTagPredicate) other;
+        return tag.equals(otherStudentHasSameTagPredicate.tag);
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this).add("tag", tag).toString();
+    }
+}

--- a/src/main/java/seedu/address/ui/PersonCard.java
+++ b/src/main/java/seedu/address/ui/PersonCard.java
@@ -51,7 +51,7 @@ public class PersonCard extends UiPart<Region> {
         name.setText(person.getName().fullName);
         studentId.setText(person.getStudentId().value);
         classId.setText(person.getClassId().value);
-        emailId.setText(person.getEmail().value);
+        emailId.setText(person.getEmail().toString());
         person.getTags().stream()
                 .sorted(Comparator.comparing(tag -> tag.tagName))
                 .forEach(tag -> tags.getChildren().add(new Label(tag.tagName)));

--- a/src/test/java/seedu/address/logic/commands/FilterCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/FilterCommandTest.java
@@ -15,7 +15,7 @@ import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
 import seedu.address.model.person.Person;
-import seedu.address.model.person.StudentHasSameIdPredicate;
+import seedu.address.model.person.StudentHasSameClassIdPredicate;
 import seedu.address.testutil.PersonBuilder;
 
 /**
@@ -27,8 +27,8 @@ public class FilterCommandTest {
 
     @Test
     public void equals() {
-        StudentHasSameIdPredicate firstPredicate = new StudentHasSameIdPredicate("CS1101S03");
-        StudentHasSameIdPredicate secondPredicate = new StudentHasSameIdPredicate("CS2040S");
+        StudentHasSameClassIdPredicate firstPredicate = new StudentHasSameClassIdPredicate("CS1101S03");
+        StudentHasSameClassIdPredicate secondPredicate = new StudentHasSameClassIdPredicate("CS2040S");
 
         FilterCommand filterFirstCommand = new FilterCommand(firstPredicate);
         FilterCommand filterSecondCommand = new FilterCommand(secondPredicate);
@@ -54,7 +54,7 @@ public class FilterCommandTest {
     public void execute_emptyId_noIdFound() {
         String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 0);
         // A class id that doesn't exist
-        StudentHasSameIdPredicate predicate = new StudentHasSameIdPredicate("");
+        StudentHasSameClassIdPredicate predicate = new StudentHasSameClassIdPredicate("");
         FilterCommand command = new FilterCommand(predicate);
         expectedModel.updateFilteredPersonList(predicate);
         assertCommandSuccess(command, model, expectedMessage, expectedModel);
@@ -64,7 +64,7 @@ public class FilterCommandTest {
     @Test
     public void execute_oneId_twoPersonsFound() {
         String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 2);
-        StudentHasSameIdPredicate predicate = new StudentHasSameIdPredicate("CS210501");
+        StudentHasSameClassIdPredicate predicate = new StudentHasSameClassIdPredicate("CS210501");
         Person james = new PersonBuilder().withName("James").withStudentId("A7777777F")
                 .withEmailId("E1230495").withClassId("CS210501").build();
         Person raj = new PersonBuilder().withName("Rajaratnam").withStudentId("A4444444G")
@@ -83,7 +83,7 @@ public class FilterCommandTest {
 
     @Test
     public void toStringMethod() {
-        StudentHasSameIdPredicate predicate = new StudentHasSameIdPredicate(("CS210605"));
+        StudentHasSameClassIdPredicate predicate = new StudentHasSameClassIdPredicate(("CS210605"));
         FilterCommand filterCommand = new FilterCommand(predicate);
         String expected = FilterCommand.class.getCanonicalName() + "{predicate=" + predicate + "}";
         assertEquals(expected, filterCommand.toString());

--- a/src/test/java/seedu/address/logic/commands/FilterCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/FilterCommandTest.java
@@ -14,8 +14,11 @@ import org.junit.jupiter.api.Test;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
+import seedu.address.model.person.ClassId;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.StudentHasSameClassIdPredicate;
+import seedu.address.model.person.StudentHasSameTagPredicate;
+import seedu.address.model.tag.Tag;
 import seedu.address.testutil.PersonBuilder;
 
 /**
@@ -26,9 +29,11 @@ public class FilterCommandTest {
     private Model expectedModel = new ModelManager(getTypicalWhoDat(), new UserPrefs());
 
     @Test
-    public void equals() {
-        StudentHasSameClassIdPredicate firstPredicate = new StudentHasSameClassIdPredicate("CS1101S03");
-        StudentHasSameClassIdPredicate secondPredicate = new StudentHasSameClassIdPredicate("CS2040S");
+    public void equals_classIdPredicate() {
+        ClassId firstClassIdPredicate = new ClassId("CS1101S03");
+        ClassId secondClassIdPredicate = new ClassId("CS2040S");
+        StudentHasSameClassIdPredicate firstPredicate = new StudentHasSameClassIdPredicate(firstClassIdPredicate);
+        StudentHasSameClassIdPredicate secondPredicate = new StudentHasSameClassIdPredicate(secondClassIdPredicate);
 
         FilterCommand filterFirstCommand = new FilterCommand(firstPredicate);
         FilterCommand filterSecondCommand = new FilterCommand(secondPredicate);
@@ -53,8 +58,9 @@ public class FilterCommandTest {
     @Test
     public void execute_emptyId_noIdFound() {
         String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 0);
-        // A class id that doesn't exist
-        StudentHasSameClassIdPredicate predicate = new StudentHasSameClassIdPredicate("");
+        // a class id that doesn't exist
+        ClassId wrongClassId = new ClassId("noexist");
+        StudentHasSameClassIdPredicate predicate = new StudentHasSameClassIdPredicate(wrongClassId);
         FilterCommand command = new FilterCommand(predicate);
         expectedModel.updateFilteredPersonList(predicate);
         assertCommandSuccess(command, model, expectedMessage, expectedModel);
@@ -63,17 +69,18 @@ public class FilterCommandTest {
 
     @Test
     public void execute_oneId_twoPersonsFound() {
+        // both people share same class id
         String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 2);
-        StudentHasSameClassIdPredicate predicate = new StudentHasSameClassIdPredicate("CS210501");
         Person james = new PersonBuilder().withName("James").withStudentId("A7777777F")
                 .withEmailId("E1230495").withClassId("CS210501").build();
         Person raj = new PersonBuilder().withName("Rajaratnam").withStudentId("A4444444G")
                 .withEmailId("E5938475").withClassId("CS210501").build();
-        expectedModel.updateFilteredPersonList(predicate);
         model.addPerson(james);
         model.addPerson(raj);
         expectedModel.addPerson(james);
         expectedModel.addPerson(raj);
+        ClassId testPredicate = new ClassId("CS210501");
+        StudentHasSameClassIdPredicate predicate = new StudentHasSameClassIdPredicate(testPredicate);
         FilterCommand command = new FilterCommand(predicate);
         model.updateFilteredPersonList(predicate);
         expectedModel.updateFilteredPersonList(predicate);
@@ -82,10 +89,80 @@ public class FilterCommandTest {
     }
 
     @Test
-    public void toStringMethod() {
-        StudentHasSameClassIdPredicate predicate = new StudentHasSameClassIdPredicate(("CS210605"));
+    public void toString_classId() {
+        ClassId testClassId = new ClassId("CS210605");
+        StudentHasSameClassIdPredicate predicate = new StudentHasSameClassIdPredicate((testClassId));
         FilterCommand filterCommand = new FilterCommand(predicate);
         String expected = FilterCommand.class.getCanonicalName() + "{predicate=" + predicate + "}";
         assertEquals(expected, filterCommand.toString());
+    }
+
+    @Test
+    public void toString_tag() {
+        Tag testTag = new Tag("NeedHelp");
+        StudentHasSameTagPredicate predicate = new StudentHasSameTagPredicate(testTag);
+        FilterCommand filterCommand = new FilterCommand(predicate);
+        String expected = FilterCommand.class.getCanonicalName() + "{predicate=" + predicate + "}";
+        assertEquals(expected, filterCommand.toString());
+    }
+
+    @Test
+    public void equals_tagPredicate() {
+        Tag firstTag = new Tag("Friend");
+        Tag secondTag = new Tag("Colleague");
+        StudentHasSameTagPredicate firstPredicate = new StudentHasSameTagPredicate(firstTag);
+        StudentHasSameTagPredicate secondPredicate = new StudentHasSameTagPredicate(secondTag);
+
+        FilterCommand filterFirstCommand = new FilterCommand(firstPredicate);
+        FilterCommand filterSecondCommand = new FilterCommand(secondPredicate);
+
+        // same object -> returns true
+        assertTrue(filterFirstCommand.equals(filterFirstCommand));
+
+        // same values -> returns true
+        FilterCommand filterFirstCommandCopy = new FilterCommand(firstPredicate);
+        assertTrue(filterFirstCommand.equals(filterFirstCommandCopy));
+
+        // different types -> returns false
+        assertFalse(filterFirstCommand.equals(1));
+
+        // null -> returns false
+        assertFalse(filterFirstCommand.equals(null));
+
+        // different tags -> returns false
+        assertFalse(filterFirstCommand.equals(filterSecondCommand));
+    }
+
+    @Test
+    public void execute_invalidTag_noPersonFound() {
+        String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 0);
+        // tag doesn't exist
+        Tag emptyTag = new Tag("noexist");
+        StudentHasSameTagPredicate predicate = new StudentHasSameTagPredicate(emptyTag);
+        FilterCommand command = new FilterCommand(predicate);
+        expectedModel.updateFilteredPersonList(predicate);
+        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+        assertEquals(Collections.emptyList(), model.getFilteredPersonList());
+    }
+
+    @Test
+    public void execute_tagFiltering_twoPersonsFound() {
+        String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 2);
+        // same tag but different cases
+        Person choony = new PersonBuilder().withName("Benny").withStudentId("A7777777F")
+                .withEmailId("E1230495").withClassId("CS210501").withTags("Friend").build();
+        Person benny = new PersonBuilder().withName("Choony").withStudentId("A4444444G")
+                .withEmailId("E5938475").withClassId("CS210501").withTags("fRieND").build();
+        model.addPerson(choony);
+        model.addPerson(benny);
+        expectedModel.addPerson(choony);
+        expectedModel.addPerson(benny);
+        Tag filterTag = new Tag("friend");
+        StudentHasSameTagPredicate predicate = new StudentHasSameTagPredicate(filterTag);
+        FilterCommand command = new FilterCommand(predicate);
+        model.updateFilteredPersonList(predicate);
+        expectedModel.updateFilteredPersonList(predicate);
+        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+        assertEquals(expectedModel.getFilteredPersonList(), model.getFilteredPersonList());
     }
 }

--- a/src/test/java/seedu/address/logic/parser/FilterCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FilterCommandParserTest.java
@@ -3,11 +3,16 @@ package seedu.address.logic.parser;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+import static seedu.address.logic.parser.FilterCommandParser.SUFFIX_FILTER_BY_CLASS;
+import static seedu.address.logic.parser.FilterCommandParser.SUFFIX_FILTER_BY_TAG;
 
 import org.junit.jupiter.api.Test;
 
 import seedu.address.logic.commands.FilterCommand;
+import seedu.address.model.person.ClassId;
 import seedu.address.model.person.StudentHasSameClassIdPredicate;
+import seedu.address.model.person.StudentHasSameTagPredicate;
+import seedu.address.model.tag.Tag;
 
 public class FilterCommandParserTest {
 
@@ -20,17 +25,23 @@ public class FilterCommandParserTest {
 
     @Test
     public void parse_validArgs_returnsFilterCommand() {
-        String validClassId = "CS323019";
-        FilterCommand expectedFilterCommand =
-                new FilterCommand(new StudentHasSameClassIdPredicate(validClassId));
-        // class id's match
-        assertParseSuccess(parser, "CS323019", expectedFilterCommand);
+        ClassId testId = new ClassId("CS2109S04");
+        FilterCommand expectedCommandForId =
+                new FilterCommand(new StudentHasSameClassIdPredicate(testId));
+        Tag testTag = new Tag("NeedHelp");
+        FilterCommand expectedCommandForTag = new FilterCommand(new StudentHasSameTagPredicate(testTag));
+
+        // class ids match
+        assertParseSuccess(parser, "CS2109S04" + SUFFIX_FILTER_BY_CLASS, expectedCommandForId);
 
         // class id with leading and trailing whitespaces
-        assertParseSuccess(parser, "  CS323019  ", expectedFilterCommand);
+        assertParseSuccess(parser, "  CS2109S04  " + SUFFIX_FILTER_BY_CLASS, expectedCommandForId);
 
-        // case insensitive
-        assertParseSuccess(parser, "cs323019", expectedFilterCommand);
+        // tags match
+        assertParseSuccess(parser, "NeedHelp" + SUFFIX_FILTER_BY_TAG, expectedCommandForTag);
+
+        // tags with leading and trailing whitespaces
+        assertParseSuccess(parser, "    NeedHelp " + SUFFIX_FILTER_BY_TAG, expectedCommandForTag);
     }
 
 }

--- a/src/test/java/seedu/address/logic/parser/FilterCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FilterCommandParserTest.java
@@ -7,7 +7,7 @@ import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSucces
 import org.junit.jupiter.api.Test;
 
 import seedu.address.logic.commands.FilterCommand;
-import seedu.address.model.person.StudentHasSameIdPredicate;
+import seedu.address.model.person.StudentHasSameClassIdPredicate;
 
 public class FilterCommandParserTest {
 
@@ -22,7 +22,7 @@ public class FilterCommandParserTest {
     public void parse_validArgs_returnsFilterCommand() {
         String validClassId = "CS323019";
         FilterCommand expectedFilterCommand =
-                new FilterCommand(new StudentHasSameIdPredicate(validClassId));
+                new FilterCommand(new StudentHasSameClassIdPredicate(validClassId));
         // class id's match
         assertParseSuccess(parser, "CS323019", expectedFilterCommand);
 

--- a/src/test/java/seedu/address/model/person/StudentHasSameClassIdPredicateTest.java
+++ b/src/test/java/seedu/address/model/person/StudentHasSameClassIdPredicateTest.java
@@ -13,12 +13,14 @@ public class StudentHasSameClassIdPredicateTest {
     @Test
     public void equals() {
         // Same class id -> returns true
-        StudentHasSameClassIdPredicate firstPredicate = new StudentHasSameClassIdPredicate("CS323019");
-        StudentHasSameClassIdPredicate secondPredicate = new StudentHasSameClassIdPredicate("CS323019");
+        ClassId testId = new ClassId("CS323019");
+        StudentHasSameClassIdPredicate firstPredicate = new StudentHasSameClassIdPredicate(testId);
+        StudentHasSameClassIdPredicate secondPredicate = new StudentHasSameClassIdPredicate(testId);
         assertTrue(firstPredicate.equals(secondPredicate));
 
         // different class ids -> returns false
-        StudentHasSameClassIdPredicate thirdPredicate = new StudentHasSameClassIdPredicate("CS1101S");
+        ClassId secondTestId = new ClassId("CS1101S");
+        StudentHasSameClassIdPredicate thirdPredicate = new StudentHasSameClassIdPredicate(secondTestId);
         assertFalse(firstPredicate.equals(thirdPredicate));
 
         // different types -> returns false
@@ -31,29 +33,32 @@ public class StudentHasSameClassIdPredicateTest {
     @Test
     public void test_classIdMatches_returnsTrue() {
         // matching class ids
-        StudentHasSameClassIdPredicate predicate = new StudentHasSameClassIdPredicate("CS323019");
-        assertTrue(predicate.test(new PersonBuilder().withClassId("CS323019").build()));
+        ClassId firstTestId = new ClassId("CS210205");
+        StudentHasSameClassIdPredicate predicate = new StudentHasSameClassIdPredicate(firstTestId);
+        assertTrue(predicate.test(new PersonBuilder().withClassId("CS210205").build()));
 
         // matching class ids but with different case
-        predicate = new StudentHasSameClassIdPredicate("cs323019");
-        assertTrue(predicate.test(new PersonBuilder().withClassId("CS323019").build()));
+        ClassId secondTestId = new ClassId("cs210205");
+        predicate = new StudentHasSameClassIdPredicate(secondTestId);
+        assertTrue(predicate.test(new PersonBuilder().withClassId("CS210205").build()));
     }
 
     @Test
     public void test_classIdDoesNotMatch_returnsFalse() {
         // non-matching class ids
-        StudentHasSameClassIdPredicate predicate = new StudentHasSameClassIdPredicate("CS323019");
-        assertFalse(predicate.test(new PersonBuilder().withClassId("CS1101S").build()));
+        ClassId firstTestId = new ClassId("CS210509");
+        StudentHasSameClassIdPredicate predicate = new StudentHasSameClassIdPredicate(firstTestId);
+        assertFalse(predicate.test(new PersonBuilder().withClassId("CS323010").build()));
 
         // non-matching with different case
-        predicate = new StudentHasSameClassIdPredicate("CS323019");
-        assertFalse(predicate.test(new PersonBuilder().withClassId("cs1101s").build()));
+        assertFalse(predicate.test(new PersonBuilder().withClassId("cs323010").build()));
     }
 
     @Test
     public void toStringMethod() {
-        StudentHasSameClassIdPredicate predicate = new StudentHasSameClassIdPredicate("CS323019");
-        String expected = StudentHasSameClassIdPredicate.class.getCanonicalName() + "{classId=cs323019}";
+        ClassId firstTestId = new ClassId("CS2030S");
+        StudentHasSameClassIdPredicate predicate = new StudentHasSameClassIdPredicate(firstTestId);
+        String expected = StudentHasSameClassIdPredicate.class.getCanonicalName() + "{classId=CS2030S}";
         assertEquals(expected, predicate.toString());
     }
 }

--- a/src/test/java/seedu/address/model/person/StudentHasSameClassIdPredicateTest.java
+++ b/src/test/java/seedu/address/model/person/StudentHasSameClassIdPredicateTest.java
@@ -8,17 +8,17 @@ import org.junit.jupiter.api.Test;
 
 import seedu.address.testutil.PersonBuilder;
 
-public class StudentHasSameIdPredicateTest {
+public class StudentHasSameClassIdPredicateTest {
 
     @Test
     public void equals() {
         // Same class id -> returns true
-        StudentHasSameIdPredicate firstPredicate = new StudentHasSameIdPredicate("CS323019");
-        StudentHasSameIdPredicate secondPredicate = new StudentHasSameIdPredicate("CS323019");
+        StudentHasSameClassIdPredicate firstPredicate = new StudentHasSameClassIdPredicate("CS323019");
+        StudentHasSameClassIdPredicate secondPredicate = new StudentHasSameClassIdPredicate("CS323019");
         assertTrue(firstPredicate.equals(secondPredicate));
 
         // different class ids -> returns false
-        StudentHasSameIdPredicate thirdPredicate = new StudentHasSameIdPredicate("CS1101S");
+        StudentHasSameClassIdPredicate thirdPredicate = new StudentHasSameClassIdPredicate("CS1101S");
         assertFalse(firstPredicate.equals(thirdPredicate));
 
         // different types -> returns false
@@ -31,29 +31,29 @@ public class StudentHasSameIdPredicateTest {
     @Test
     public void test_classIdMatches_returnsTrue() {
         // matching class ids
-        StudentHasSameIdPredicate predicate = new StudentHasSameIdPredicate("CS323019");
+        StudentHasSameClassIdPredicate predicate = new StudentHasSameClassIdPredicate("CS323019");
         assertTrue(predicate.test(new PersonBuilder().withClassId("CS323019").build()));
 
         // matching class ids but with different case
-        predicate = new StudentHasSameIdPredicate("cs323019");
+        predicate = new StudentHasSameClassIdPredicate("cs323019");
         assertTrue(predicate.test(new PersonBuilder().withClassId("CS323019").build()));
     }
 
     @Test
     public void test_classIdDoesNotMatch_returnsFalse() {
         // non-matching class ids
-        StudentHasSameIdPredicate predicate = new StudentHasSameIdPredicate("CS323019");
+        StudentHasSameClassIdPredicate predicate = new StudentHasSameClassIdPredicate("CS323019");
         assertFalse(predicate.test(new PersonBuilder().withClassId("CS1101S").build()));
 
         // non-matching with different case
-        predicate = new StudentHasSameIdPredicate("CS323019");
+        predicate = new StudentHasSameClassIdPredicate("CS323019");
         assertFalse(predicate.test(new PersonBuilder().withClassId("cs1101s").build()));
     }
 
     @Test
     public void toStringMethod() {
-        StudentHasSameIdPredicate predicate = new StudentHasSameIdPredicate("CS323019");
-        String expected = StudentHasSameIdPredicate.class.getCanonicalName() + "{classId=cs323019}";
+        StudentHasSameClassIdPredicate predicate = new StudentHasSameClassIdPredicate("CS323019");
+        String expected = StudentHasSameClassIdPredicate.class.getCanonicalName() + "{classId=cs323019}";
         assertEquals(expected, predicate.toString());
     }
 }

--- a/src/test/java/seedu/address/model/person/StudentHasSameTagPredicateTest.java
+++ b/src/test/java/seedu/address/model/person/StudentHasSameTagPredicateTest.java
@@ -1,0 +1,65 @@
+package seedu.address.model.person;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.model.tag.Tag;
+import seedu.address.testutil.PersonBuilder;
+
+public class StudentHasSameTagPredicateTest {
+
+    @Test
+    public void equals() {
+        // same tag -> returns true
+        Tag testTag = new Tag("NeedHelp");
+        StudentHasSameTagPredicate firstPredicate = new StudentHasSameTagPredicate(testTag);
+        StudentHasSameTagPredicate secondPredicate = new StudentHasSameTagPredicate(testTag);
+        assertTrue(firstPredicate.equals(secondPredicate));
+
+        // different tags -> returns false
+        Tag secondTestTag = new Tag("NoSubmission");
+        StudentHasSameTagPredicate thirdPredicate = new StudentHasSameTagPredicate(secondTestTag);
+        assertFalse(firstPredicate.equals(thirdPredicate));
+
+        // different types -> returns false
+        assertFalse(firstPredicate.equals(1));
+
+        // Null -> returns false
+        assertFalse(firstPredicate.equals(null));
+    }
+
+    @Test
+    public void test_tagMatches_returnsTrue() {
+        // matching tags
+        Tag firstTestTag = new Tag("LateSubmission");
+        StudentHasSameTagPredicate predicate = new StudentHasSameTagPredicate(firstTestTag);
+        assertTrue(predicate.test(new PersonBuilder().withTags("LateSubmission").build()));
+
+        // matching tags but with different case
+        Tag secondTestTag = new Tag("latesubmission");
+        predicate = new StudentHasSameTagPredicate(secondTestTag);
+        assertTrue(predicate.test(new PersonBuilder().withTags("LateSubmission").build()));
+    }
+
+    @Test
+    public void test_tagDoesNotMatch_returnsFalse() {
+        // non-matching tags
+        Tag firstTestTag = new Tag("NeedHelp");
+        StudentHasSameTagPredicate predicate = new StudentHasSameTagPredicate(firstTestTag);
+        assertFalse(predicate.test(new PersonBuilder().withTags("NoSubmission").build()));
+
+        // non-matching with different case
+        assertFalse(predicate.test(new PersonBuilder().withTags("nosubmission").build()));
+    }
+
+    @Test
+    public void toStringMethod() {
+        Tag firstTestTag = new Tag("NeedHelp");
+        StudentHasSameTagPredicate predicate = new StudentHasSameTagPredicate(firstTestTag);
+        String expected = StudentHasSameTagPredicate.class.getCanonicalName() + "{tag=[NeedHelp]}";
+        assertEquals(expected, predicate.toString());
+    }
+}


### PR DESCRIPTION
* Filter can now work with tags
* Filter command format is now changed to `filter_c classid` and `filter_t tag`
* The commands will need to be changed in the user guide, but it's a small issue, I can fix it in my upcoming commits
* Fix minor email UI bug where the @u.nus.edu was not appended to the email

Fixes #86 
Fixes #81 